### PR TITLE
[WIP] Glue plugin to work with Glue 0.11

### DIFF
--- a/glue_ginga/plugins/Glue.py
+++ b/glue_ginga/plugins/Glue.py
@@ -309,8 +309,8 @@ Press "Close" to close this plugin. This also closes the associated Glue session
 
         # self.glue_app._create_terminal()
         sgeo = self.glue_app.app.desktop().screenGeometry()
+        self.glue_app.show()
         self.glue_app.resize(sgeo.width() * 0.9, sgeo.height() * 0.9)
-        self.glue_app.start(maximized=False)
         # self.glue_app.lower()
 
         # Toggle buttons accordingly.

--- a/glue_ginga/plugins/Glue.py
+++ b/glue_ginga/plugins/Glue.py
@@ -310,7 +310,7 @@ Press "Close" to close this plugin. This also closes the associated Glue session
         # self.glue_app._create_terminal()
         sgeo = self.glue_app.app.desktop().screenGeometry()
         self.glue_app.resize(sgeo.width() * 0.9, sgeo.height() * 0.9)
-        self.glue_app.show()
+        self.glue_app.start(maximized=False)
         # self.glue_app.lower()
 
         # Toggle buttons accordingly.
@@ -375,7 +375,7 @@ def qglue():
     # Suppress pesky Glue warnings.
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', GlueDeprecationWarning)
-        ga = GlueApplication(data_collection=dc, maximized=False)
+        ga = GlueApplication(data_collection=dc)
 
     return ga
 


### PR DESCRIPTION
Fix #22 

The first commit is as suggested in https://github.com/ejeschke/glue-ginga/issues/22#issuecomment-325045547 . However this does not fix other problems.

When I use the Glue plugin with the fix from the first commit, I see some cryptic message:
```
QTextCursor::setPosition: Position '-1' out of range
QTextCursor::setPosition: Position '10' out of range
```

Then, Ginga refuses to load image properly after Glue plugin is started.

Also, when I click on the "x" to close Glue started from within this plugin, I get a bunch of traceback related to Qt not able to find stuff, which is sometimes followed by a core dump.

tl;dr -- More investigation is needed to make this plugin work again under Ginga dev and Glue 0.11.